### PR TITLE
Fix: Simplified build script in package.json by removing unnecessary NODE_OPTIONS,

### DIFF
--- a/apps/dexappbuilder/package.json
+++ b/apps/dexappbuilder/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "cross-env NODE_OPTIONS=\"--max-old-space-size=12288\" next dev",
     "prebuild": "node scripts/update-version-json.js",
-    "build": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192 --max-http-header-size=16384 --no-warnings --max-semi-space-size=512\" next build",
+    "build": "next build",
     "start": "next start -p $PORT",
     "lint": "next lint",
     "test": "jest",


### PR DESCRIPTION
I had this error trying to simplify the build on Windows but ended up reverting it