### PR TITLE
fix: first build after cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,19 @@ This monorepo uses Yarn as the preferred package manager.
 git clone https://github.com/DexKit/dexkit-monorepo.git
 cd dexkit-monorepo
 
-# Install dependencies
+# Install dependencies and build packages automatically
 yarn install
+# Note: The postinstall script will automatically build all required packages
 
+# Alternative: Manual setup (if needed)
+yarn setup
+```
+
+> **📝 Note**: After cloning, the `yarn install` command automatically builds all internal packages to prevent module resolution errors. This ensures all `@dexkit/*` packages are properly compiled and available.
+
+### Environment Setup
+
+```bash
 # Set up environment variables for DexAppBuilder
 cp apps/dexappbuilder/.env.example apps/dexappbuilder/.env
 
@@ -51,6 +61,24 @@ yarn dev
 cd apps/coinleague
 yarn dev
 # Visit http://localhost:3001
+```
+
+## 🔧 Troubleshooting
+
+### Module Resolution Issues
+If you encounter errors like `Module not found: Can't resolve '@dexkit/dexappbuilder-render'`, it means the internal packages haven't been built. This is automatically handled by the postinstall script, but you can manually resolve it:
+
+```bash
+# Build all required packages
+yarn build:packages
+
+# Or build individual packages in dependency order
+yarn workspace @dexkit/ui build
+yarn workspace @dexkit/core build
+yarn workspace @dexkit/unlock-widget build
+yarn workspace @dexkit/darkblock-evm-widget build
+yarn workspace @dexkit/dexappbuilder-render build
+yarn workspace @dexkit/dexappbuilder-viewer build
 ```
 
 ### General Guidelines:
@@ -83,3 +111,4 @@ This project is licensed under the MIT License.
 <div align="center">
   Made with ❤️ by <a href="https://dexkit.com">DexKit</a>
 </div>
+

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "packages/*"
   ],
   "scripts": {
+    "postinstall": "yarn build:packages",
+    "setup": "yarn install && yarn build:packages",
+    "verify": "node scripts/verify-setup.js",
     "clean-daemon": "turbo daemon clean",
     "build": "turbo run build",
     "release": "turbo run release --filter=@dexkit/ui,@dexkit/web3forms,@dexkit/widgets,@dexkit/dexappbuilder-viewer,@dexkit/core",
@@ -23,7 +26,7 @@
     "storybook:widget": "turbo run storybook --filter=@dexkit/widgets",
     "storybook:exchange": "turbo run storybook --filter=@dexkit/exchange",
     "bundle:widgets": "turbo run bundle:widgets",
-    "build:packages": "turbo run build --parallel",
+    "build:packages": "turbo run build --filter=@dexkit/unlock-widget --filter=@dexkit/darkblock-evm-widget --filter=@dexkit/dexappbuilder-render",
     "build:parallel": "turbo run build --parallel",
     "build:whitelabel": "turbo run build --filter=@dexkit/unlock-widget --filter=@dexkit/@dexkit/dexappbuilder-render --filter=dexappbuilder ",
     "build:dexappadmin": "turbo run build --filter=@dexkit/@dexkit/dexappbuilder-render  --filter=dexappadmin",

--- a/scripts/verify-setup.js
+++ b/scripts/verify-setup.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+// Only check packages that actually need to be built (have TypeScript compilation)
+const packagesToCheck = [
+  '@dexkit/unlock-widget',
+  '@dexkit/darkblock-evm-widget',
+  '@dexkit/dexappbuilder-render'
+];
+
+const packagePaths = {
+  '@dexkit/unlock-widget': 'packages/dexkit-unlock',
+  '@dexkit/darkblock-evm-widget': 'packages/dexkit-darkblock',
+  '@dexkit/dexappbuilder-render': 'packages/dexappbuilder-render'
+};
+
+// Check if packages that don't need building exist
+const sourcePackages = [
+  { name: '@dexkit/ui', path: 'packages/dexkit-ui' },
+  { name: '@dexkit/core', path: 'packages/dexkit-core' },
+  { name: '@dexkit/dexappbuilder-viewer', path: 'packages/dexappbuilder-viewer' }
+];
+
+console.log('🔍 Verifying DexKit monorepo setup...\n');
+
+let allGood = true;
+
+// Check source packages (no build required)
+console.log('📁 Source packages (no build required):');
+for (const pkg of sourcePackages) {
+  if (fs.existsSync(path.join(pkg.path, 'package.json'))) {
+    console.log(`✅ ${pkg.name} - Available`);
+  } else {
+    console.log(`❌ ${pkg.name} - Missing`);
+    allGood = false;
+  }
+}
+
+console.log('\n🔨 Built packages (require compilation):');
+// Check packages that need to be built
+for (const pkg of packagesToCheck) {
+  const pkgPath = packagePaths[pkg];
+  const distPath = path.join(pkgPath, 'dist');
+
+  if (fs.existsSync(distPath)) {
+    const files = fs.readdirSync(distPath);
+    if (files.length > 0) {
+      console.log(`✅ ${pkg} - Built successfully`);
+    } else {
+      console.log(`❌ ${pkg} - Dist folder is empty`);
+      allGood = false;
+    }
+  } else {
+    console.log(`❌ ${pkg} - Not built (missing dist folder)`);
+    allGood = false;
+  }
+}
+
+console.log('\n' + '='.repeat(50));
+
+if (allGood) {
+  console.log('🎉 All packages are properly set up! You\'re ready to develop.');
+  console.log('\nNext steps:');
+  console.log('1. Set up environment variables (check README.md)');
+  console.log('2. Run your desired app:');
+  console.log('   - yarn dev:whitelabel (DexAppBuilder)');
+  console.log('   - yarn dev:coinleague (Coin League)');
+  console.log('   - yarn dev:wallet-example (Wallet Example)');
+} else {
+  console.log('⚠️  Some packages need to be built. Run the following to fix:');
+  console.log('   yarn build:packages');
+  console.log('\nOr run individual builds for packages that need it:');
+  console.log('   yarn workspace @dexkit/unlock-widget build');
+  console.log('   yarn workspace @dexkit/darkblock-evm-widget build');
+  console.log('   yarn workspace @dexkit/dexappbuilder-render build');
+  process.exit(1);
+}


### PR DESCRIPTION
Problem:
After `git clone`, developers immediately encounter module resolution errors when trying to run any app:
This happens because internal monorepo packages require TypeScript compilation but aren't built automatically after cloning.

Solution:
This PR implements automatic package building to ensure a smooth developer experience from the first `git clone`

Changes Made:
- automatic Setup: Added `postinstall` script that runs `yarn build:packages` after `yarn install`
- verification Tool: New `yarn verify` command to check which packages are built and ready
- optimized Builds: Updated `build:packages` to only compile packages that actually require building
- documentation: Added troubleshooting section in README with clear instructions

Technical Details:
- Only builds packages with TypeScript compilation: `@dexkit/unlock-widget`, `@dexkit/darkblock-evm-widget`, `@dexkit/dexappbuilder-render`
- source packages like `@dexkit/ui` and `@dexkit/core` don't need building
- Smart verification script categorizes packages and provides helpful error messages